### PR TITLE
Fix issue #168

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -648,7 +648,7 @@ class WikipediaPage(object):
       #  query_params.update({'page': self.title})
 
       #request = _wiki_request(query_params)
-    section_regx = re.compile(u"== (.*?) ==")
+    section_regx = re.compile(u"== (.*?) ={2,3}\n")
     print(self.content)
     self._sections = section_regx.findall(self.content)
       #self._sections = [section['line'] for section in request['parse']['sections']]

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -638,17 +638,19 @@ class WikipediaPage(object):
     List of section titles from the table of contents on the page.
     '''
 
-    if not getattr(self, '_sections', False):
-      query_params = {
-        'action': 'parse',
-        'prop': 'sections',
-      }
+    #if not getattr(self, '_sections', False):
+      #query_params = {
+      #  'action': 'parse',
+      #  'prop': 'sections',
+      #}
 
-      if getattr(self, 'title', None) is not None:
-        query_params.update({'page': self.title})
+      #if getattr(self, 'title', None) is not None:
+      #  query_params.update({'page': self.title})
 
-      request = _wiki_request(query_params)
-      self._sections = [section['line'] for section in request['parse']['sections']]
+      #request = _wiki_request(query_params)
+    section_regx = re.compile(u"== {(.*?)} ==")
+    self._sections = section_regx.findall(sel.content)
+      #self._sections = [section['line'] for section in request['parse']['sections']]
 
     return self._sections
 

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -648,7 +648,8 @@ class WikipediaPage(object):
       #  query_params.update({'page': self.title})
 
       #request = _wiki_request(query_params)
-    section_regx = re.compile(u"== {(.*?)} ==")
+    section_regx = re.compile(u"== (.*?) ==")
+    print(self.content)
     self._sections = section_regx.findall(self.content)
       #self._sections = [section['line'] for section in request['parse']['sections']]
 

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -636,22 +636,14 @@ class WikipediaPage(object):
   def sections(self):
     '''
     List of section titles from the table of contents on the page.
+    NOTE: This method does not use the wikipedia api to request the 
+    table of content. Because the output of this api function differs
+    from the formating of the section tiles in the `section` function
+    of this class.
     '''
 
-    #if not getattr(self, '_sections', False):
-      #query_params = {
-      #  'action': 'parse',
-      #  'prop': 'sections',
-      #}
-
-      #if getattr(self, 'title', None) is not None:
-      #  query_params.update({'page': self.title})
-
-      #request = _wiki_request(query_params)
-    section_regx = re.compile(u"== (.*?) ={2,3}\n")
-    print(self.content)
+    section_regx = re.compile(u"== (.*?) ==")
     self._sections = section_regx.findall(self.content)
-      #self._sections = [section['line'] for section in request['parse']['sections']]
 
     return self._sections
 

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -649,7 +649,7 @@ class WikipediaPage(object):
 
       #request = _wiki_request(query_params)
     section_regx = re.compile(u"== {(.*?)} ==")
-    self._sections = section_regx.findall(sel.content)
+    self._sections = section_regx.findall(self.content)
       #self._sections = [section['line'] for section in request['parse']['sections']]
 
     return self._sections


### PR DESCRIPTION
Fixes issue #168 In this commit the table of content is not retrieved by a query to the API, because the formatting of this output causes issues when matching it to the content retrieved by this module (which has the wiki formatting)